### PR TITLE
Align chat to top

### DIFF
--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -564,12 +564,16 @@ class ChatPageState extends State<ChatPage> {
                 if (snapshot.hasData) {
                   _listMessage = snapshot.data!.docs;
                   if (_listMessage.length > 0) {
-                    return ListView.builder(
-                      padding: EdgeInsets.all(10),
-                      itemBuilder: (_, index) => _buildItemMessage(index, snapshot.data?.docs[index]),
-                      itemCount: snapshot.data?.docs.length,
-                      reverse: true,
-                      controller: _listScrollController,
+                    return Align(
+                      alignment: Alignment.topCenter,
+                      child: ListView.builder(
+                        padding: EdgeInsets.all(10),
+                        itemBuilder: (_, index) => _buildItemMessage(index, snapshot.data?.docs[index]),
+                        itemCount: snapshot.data?.docs.length,
+                        shrinkWrap: true,
+                        reverse: true,
+                        controller: _listScrollController,
+                      ),
                     );
                   } else {
                     return Center(child: Text("No message here yet..."));


### PR DESCRIPTION
Thanks for the great demo app. 
I'm not sure if the chat UI being stacked at the bottom is intentional design or not, but this PR is for when the design was not intentional.
This PR allows chats to be stacked from the top, not the bottom. 

The important part of aligning the ListView is to set `shrinkWrap` to true since it limits the height of the ListView so that the `Align` can place the ListView at the top. 

### **Before**
![121046493_01](https://github.com/duytq94/flutter-chat-demo/assets/97279763/b70668e9-620c-41e4-a06f-892b19384767)


### **After**
![121046493](https://github.com/duytq94/flutter-chat-demo/assets/97279763/e320a012-1913-44cc-a907-924def1a8665)
